### PR TITLE
Add notice about install of brickrun

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Documentation
 * [Online](doc/brickrun.rst)
 
 
+Install
+-------
+
+    If you are running an ev3dev "stretch" image and yet Visual Studio Code reports
+        brickrun: command not found
+    you may need to install brickrun:
+        sudo apt update && sudo apt install brickrun
+
+
 Hacking
 -------
 


### PR DESCRIPTION
Silly me, took me quite some time to discover I *only* needed to install brickrun. 
Had stretch running on my brick but an older stretch snapshot image, updated to the current status. 
But that did not automatically install brickrun, obviously.